### PR TITLE
chore(ci): Diferencia la compilación de CI para Windows y Unix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,13 +170,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-cargo-
 
-      - name: Build
+      - name: Build (Unix)
+        if: runner.os != 'Windows'
         run: |
           # Try building with system OpenSSL first
           if ! cargo build --release --target ${{ matrix.target }}; then
             echo "System OpenSSL build failed, trying with vendored OpenSSL..."
             cargo build --release --target ${{ matrix.target }} --features vendored-openssl
           fi
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: cargo build --release --target ${{ matrix.target }} --features vendored-openssl
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/OPENSSL_SOLUTIONS.md
+++ b/OPENSSL_SOLUTIONS.md
@@ -62,8 +62,10 @@ Improved the CI workflow with:
 ```
 
 #### Smart Build Strategy
+**Unix Systems (Linux/macOS):**
 ```yaml
-- name: Build
+- name: Build (Unix)
+  if: runner.os != 'Windows'
   run: |
     # Try building with system OpenSSL first
     if ! cargo build --release --target ${{ matrix.target }}; then
@@ -72,11 +74,22 @@ Improved the CI workflow with:
     fi
 ```
 
-### 3. 🏗️ **Build Strategy Hierarchy**
-The workflow now follows this fallback strategy:
+**Windows:**
+```yaml
+- name: Build (Windows)
+  if: runner.os == 'Windows'
+  run: cargo build --release --target ${{ matrix.target }} --features vendored-openssl
+```
 
+### 3. 🏗️ **Build Strategy by Platform**
+The workflow uses different strategies per platform:
+
+#### Unix Systems (Linux/macOS)
 1. **Try system OpenSSL** (faster, smaller binary)
 2. **Fallback to vendored OpenSSL** (always works, larger binary)
+
+#### Windows
+1. **Always use vendored OpenSSL** (Windows doesn't have system OpenSSL)
 
 ## Environment Variables Set
 
@@ -137,3 +150,14 @@ cargo build --release --target aarch64-apple-darwin
 ✅ **Use vendored OpenSSL in CI** for reliability
 ✅ **Use system OpenSSL locally** for faster builds
 ✅ **The workflow automatically handles both** scenarios 
+
+## Platform-Specific Notes
+
+### Windows
+- **Always uses vendored OpenSSL** since Windows doesn't ship with OpenSSL
+- **No fallback needed** - vendored is the reliable approach
+- **Avoids shell syntax issues** between PowerShell and bash
+
+### Linux/macOS  
+- **Tries system OpenSSL first** for optimal performance
+- **Automatic fallback** ensures builds always succeed 


### PR DESCRIPTION
Se ha refactorizado el flujo de trabajo de integración continua (CI) en `.github/workflows/release.yml` para gestionar de forma diferenciada la compilación en sistemas Unix (Linux/macOS) y Windows. Anteriormente, existía un único paso de compilación que intentaba usar el OpenSSL del sistema y, en caso de fallo, recurría a una versión 'vendored' (compilada junto al proyecto). Esta estrategia fallaba sistemáticamente en los runners de Windows, ya que no disponen de una instalación de OpenSSL a nivel de sistema y la sintaxis del script de fallback no es compatible con la shell por defecto (PowerShell). Para solucionar esto, el paso de 'Build' se ha dividido en dos lógicas condicionales: una para Unix (`if: runner.os != 'Windows'`) que mantiene la estrategia de fallback original, y una nueva para Windows (`if: runner.os == 'Windows'`) que compila directamente con la feature `--features vendored-openssl`. Este cambio garantiza la fiabilidad y el éxito de las compilaciones en todas las plataformas. Adicionalmente, se ha actualizado la documentación en `OPENSSL_SOLUTIONS.md` para reflejar con precisión esta nueva estrategia de compilación por plataforma, detallando el porqué de cada enfoque y mejorando la mantenibilidad y comprensión del pipeline de CI.

BREAKING CHANGE: N/A

Test Details: N/A

Security: N/A

Migraciones Lentas: N/A

Partes a Ejecutar: N/A

JIRA TASKS: N/A