### PR TITLE
chore(ci/cd): Añade log de depuración al workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           #NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: |
+
+          echo "GITHUB_TOKEN: $GITHUB_TOKEN"
+          echo $GITHUB_TOKEN
+          
+          npx semantic-release
 
   build-cross-platform:
     name: Build Cross-Platform


### PR DESCRIPTION
Se ha modificado el archivo de configuración del flujo de trabajo de GitHub Actions ubicado en `.github/workflows/release.yml`. Específicamente, dentro del `job` denominado `release`, se ha alterado el paso que ejecuta `semantic-release`. Anteriormente, este paso contenía una única instrucción `run: npx semantic-release`. La actualización convierte este paso en un script multilínea, introduciendo el comando `echo $GITHUB_TOKEN` inmediatamente antes de la ejecución de `semantic-release`. El propósito fundamental de este cambio es la depuración del proceso de CI/CD. Al imprimir el valor de la variable de entorno `GITHUB_TOKEN` en los logs del workflow, se busca verificar si el secreto se está inyectando y pasando correctamente al entorno de ejecución. Esta es una técnica de diagnóstico común para resolver problemas de autenticación con la API de GitHub que `semantic-release` necesita para crear tags, publicaciones de release y comentarios en pull requests. El impacto funcional en caso de éxito es nulo, pero su principal consecuencia es la observabilidad del pipeline. No obstante, introduce una grave vulnerabilidad de seguridad al exponer un token sensible en los logs, un riesgo que debe ser mitigado eliminando esta línea una vez finalizada la depuración.

BREAKING CHANGE: N/A

Test Details: N/A

Security: Se ha detectado una vulnerabilidad de seguridad crítica de tipo 'Exposición de Información Confidencial'. El cambio introduce la línea `echo $GITHUB_TOKEN` en el workflow de `release.yml`. Esta instrucción imprime el valor del secreto `GITHUB_TOKEN` directamente en los logs de ejecución de GitHub Actions. Aunque GitHub Actions intenta enmascarar automáticamente los secretos en los logs, este mecanismo no es infalible y puede ser eludido. La exposición de este token, que generalmente posee permisos de escritura en el repositorio (para crear releases, tags, etc.), permitiría a cualquier persona con acceso a los logs (incluyendo colaboradores con acceso de solo lectura en repositorios públicos) comprometer la integridad del repositorio. Un atacante podría usar el token para publicar versiones maliciosas, eliminar releases existentes o realizar otras acciones no autorizadas en el repositorio, representando un riesgo de seguridad muy elevado. Esta línea debe ser eliminada inmediatamente después de completar la depuración.

Migraciones Lentas: N/A

Partes a Ejecutar: N/A

JIRA TASKS: N/A