### PR TITLE
fix(commit): Omite pie de página 'BREAKING CHANGE' si no aplica

### DIFF
--- a/src/app/commit_operations.rs
+++ b/src/app/commit_operations.rs
@@ -41,12 +41,10 @@ impl CommitOperations for App {
             message.push_str("N/A");
         }
 
-        // Breaking changes
-        message.push_str("\n\nBREAKING CHANGE: ");
+        // Breaking changes - only include if there are actual breaking changes
         if !self.commit_form.breaking_change.is_empty() {
+            message.push_str("\n\nBREAKING CHANGE: ");
             message.push_str(&self.commit_form.breaking_change);
-        } else {
-            message.push_str("N/A");
         }
 
         // Test details


### PR DESCRIPTION
Se ha realizado una corrección crucial en la lógica de generación de mensajes de commit, ubicada en el archivo `src/app/commit_operations.rs`. El cambio aborda un comportamiento incorrecto en la forma en que se adjuntaba la sección de cambios que rompen la compatibilidad (`BREAKING CHANGE`). Anteriormente, el código agregaba incondicionalmente el prefijo `\n\nBREAKING CHANGE: ` a todos los mensajes de commit generados. Posteriormente, si no se había especificado un texto para esta sección en el formulario (`self.commit_form.breaking_change.is_empty()` era verdadero), el sistema añadía el texto "N/A". Esto resultaba en la inclusión de un pie de página `BREAKING CHANGE: N/A` en commits que no introducían ninguna ruptura de compatibilidad, lo cual contraviene las especificaciones de Conventional Commits y añade ruido innecesario al historial del repositorio. La modificación actual refactoriza esta lógica para que sea condicional. Ahora, el prefijo `BREAKING CHANGE: ` y la descripción correspondiente solo se añaden al mensaje si, y solo si, el campo `breaking_change` del formulario contiene texto. Se ha eliminado por completo la rama `else` que agregaba "N/A". Este ajuste asegura que los mensajes de commit generados sean limpios y cumplan estrictamente con el estándar, mejorando la calidad y la semántica del historial de versiones.

Test Details: N/A

Security: N/A

Migraciones Lentas: N/A

Partes a Ejecutar: N/A

JIRA TASKS: N/A